### PR TITLE
Extend documentation for format-precice-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,18 @@ You may need to exclude directories using `exclude`.
 
 ### format-precice-config
 
-Formats given preCICE configuration files.
-Returns 0 on success, 1 on error, and 2 if a file was modified.
+Formats given preCICE configuration files. You can use this script standalone, overwriting each file, as:
+
+```shell
+format_precice_config.py precice-config.xml
+```
+
+The script returns 0 on success, 1 on error, and 2 if a file was modified.
+
+You may want to define an alias for convenience:
+
+```shell
+function preciceConfigFormat(){
+  /path/to/format_precice_config.py "${1:-precice-config.xml}"
+}
+```


### PR DESCRIPTION
Some aspects were a bit unclear to me before, and I was missing the convenient way to use it.

This extends the documentation and adds a hint for a bash alias.

Related to https://github.com/precice/precice/pull/1501

Edit: This is now duplicating https://github.com/precice/precice.github.io/pull/235, I am not sure if we should merge both (but why not). Maybe I should just remove the alias from here.