### PR TITLE
Install setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ packages =
 python_requires = >=3.7
 install_requires =
     lxml
+    setuptools
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
I installed `pre-commit` using `sudo apt install pre-commit`. Note: the instructions provided [here](https://pre-commit.com/#install) suggest using `pip` but this does not work smoothly since Ubuntu24.04 due to some policy changes regarding the `--user` flag.

When trying to run `pre-commit` in our main preCICE repository I got the following problem:
```
clang-format.............................................................Failed
- hook id: clang-format
- exit code: 1

Traceback (most recent call last):
  File "/home/benjamin/.cache/pre-commit/repo8_dq7otg/py_env-python3/bin/clang-format", line 5, in <module>
    from clang_format import clang_format
  File "/home/benjamin/.cache/pre-commit/repo8_dq7otg/py_env-python3/lib/python3.12/site-packages/clang_format/__init__.py", line 5, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

I fixed it by manually installing `setuptools` in the environment used by `pre-commit`:

```
/home/benjamin/.cache/pre-commit/repobqdmo7_q/py_env-python3/bin/pip3 install setuptools
```

I hope the suggested fix is a general solution to this problem. But I'm unsure how `pre-commit` exactly works and I'm also not sure how I could easily test this change now.