### PR TITLE
Enhance format_precice_config.py (pre-commit hook script) 

### DIFF
--- a/format_precice_config/format_precice_config.py
+++ b/format_precice_config/format_precice_config.py
@@ -212,16 +212,6 @@ class PrettyPrinter():
                 if data_elements and mapping_elements:
                     self.print()
                 
-                # Separate mapping elements with and without basis-function
-                mapping_with_basis = [
-                    elem for elem in mapping_elements 
-                    if any('basis-function:' in str(child.tag) for child in elem.getchildren())
-                ]
-                mapping_without_basis = [
-                    elem for elem in mapping_elements 
-                    if not any('basis-function:' in str(child.tag) for child in elem.getchildren())
-                ]
-                
                 # Print mapping elements with multi-line formatting
                 for mapping_elem in mapping_elements:
                     # Check if the mapping element has a basis-function child

--- a/format_precice_config/format_precice_config.py
+++ b/format_precice_config/format_precice_config.py
@@ -254,37 +254,37 @@ class PrettyPrinter():
                     elem for elem in other_elements 
                     if str(elem.tag) in ['participants', 'max-time', 'time-window-size']
                 ]
+                # Print initial elements first
                 for child in initial_elements:
                     self.printElement(child, level + 1)
+                    # Remove the printed elements from the list
+                    other_elements.remove(child)
                 
-                # Print convergence measures first
-                if convergence_elements:
+                if other_elements:
                     if initial_elements:
+                        self.print()
+                    # Print all other elements
+                    for child in other_elements:
+                        self.printElement(child, level + 1)
+                
+                # Print convergence measures
+                if convergence_elements:
+                    # Add newline before convergence measures if there are initial elements
+                    if initial_elements or other_elements:
                         self.print()
                     for conv in convergence_elements:
                         self.printElement(conv, level + 1)
                 
                 # Print exchanges
                 if exchange_elements:
-                    if initial_elements or convergence_elements:
+                    if initial_elements or convergence_elements or other_elements:
                         self.print()
                     for exchange in exchange_elements:
                         self.printElement(exchange, level + 1)
                 
-                # Print max-iterations if present
-                max_iterations = [
-                    elem for elem in other_elements 
-                    if str(elem.tag) == 'max-iterations'
-                ]
-                if max_iterations:
-                    if exchange_elements or convergence_elements or initial_elements:
-                        self.print()
-                    for child in max_iterations:
-                        self.printElement(child, level + 1)
-                
                 # Print acceleration elements
                 if acceleration_elements:
-                    if exchange_elements or convergence_elements or max_iterations or initial_elements:
+                    if exchange_elements or convergence_elements or initial_elements or other_elements:
                         self.print()
                     for child in acceleration_elements:
                         self.printElement(child, level + 1)

--- a/format_precice_config/format_precice_config.py
+++ b/format_precice_config/format_precice_config.py
@@ -117,23 +117,192 @@ class PrettyPrinter():
                 self.printElement(child, level=level)
             return
 
-        groups1 = itertools.groupby(element.getchildren(),
-                                    lambda e: str(e.tag).split(':')[0])
+        # Custom sorting for top-level elements
+        def custom_sort_key(elem):
+            tag = str(elem.tag)
+            # Predefined order for top-level elements with prefix matching
+            order = {
+                'data:': 1,  # Matches data:vector, data:scalar, etc.
+                'mesh': 2,
+                'participant': 3,
+                'm2n:': 4,
+                'coupling-scheme:': 5
+            }
+            # Find the first matching key
+            for prefix, rank in order.items():
+                if tag.startswith(prefix):
+                    return rank
+            return 6  # Unknown elements appear last
 
-        groups = []
+        # Sort children based on the predefined order
+        sorted_children = sorted(element.getchildren(), key=custom_sort_key)
 
-        for _, group in groups1:
-            group = list(group)
-            if isEmptyTag(group[0]):
-                groups.append(group)
-            else:
-                groups += [[e] for e in group]
-
-        last = len(groups)
-        for i, group in enumerate(groups, start=1):
-            for child in group:
-                self.printElement(child, level=level)
-            if not (isComment(group[0]) or (i == last)):
+        last = len(sorted_children)
+        for i, group in enumerate(sorted_children, start=1):
+            # Special handling for participants to reorder child elements
+            if 'participant' in str(group.tag):
+                # Define order for participant child elements with more generalized matching
+                participant_order = {
+                    'provide-mesh': 1,
+                    'receive-mesh': 2,
+                    'write-data': 3,
+                    'read-data': 4,
+                    'mapping:': 5  # Matches mapping:nearest-neighbor, mapping:rbf, etc.
+                }
+                
+                # Sort participant's children based on the defined order
+                sorted_participant_children = sorted(
+                    group.getchildren(), 
+                    key=lambda child: next(
+                        (rank for prefix, rank in participant_order.items() 
+                         if str(child.tag).startswith(prefix)), 
+                        6  # Unknown elements appear last
+                    )
+                )
+                
+                # Separate different types of elements
+                mesh_elements = []
+                data_elements = []
+                mapping_elements = []
+                
+                for child in sorted_participant_children:
+                    if str(child.tag) in ['provide-mesh', 'receive-mesh']:
+                        mesh_elements.append(child)
+                    elif str(child.tag) in ['write-data', 'read-data']:
+                        data_elements.append(child)
+                    elif str(child.tag).startswith('mapping:'):
+                        mapping_elements.append(child)
+                
+                # Construct participant tag with attributes
+                participant_tag = "<{}".format(group.tag)
+                for attr, value in group.items():
+                    participant_tag += ' {}="{}"'.format(attr, value)
+                participant_tag += ">"
+                
+                # Print participant opening tag
+                self.print(self.indent * level + participant_tag)
+                
+                # Print mesh elements
+                for child in mesh_elements:
+                    self.printElement(child, level + 1)
+                
+                # Add newline between mesh and data
+                if mesh_elements and data_elements:
+                    self.print()
+                
+                # Print data elements
+                for child in data_elements:
+                    self.printElement(child, level + 1)
+                
+                # Add newline before mapping
+                if data_elements and mapping_elements:
+                    self.print()
+                
+                # Print mapping elements with multi-line formatting
+                for mapping_elem in mapping_elements:
+                    # Check if the mapping element has multiple attributes
+                    if len(mapping_elem.items()) > 2:
+                        self.print("{}<{}".format(self.indent * (level + 1), mapping_elem.tag))
+                        for k, v in mapping_elem.items():
+                            self.print("{}{}=\"{}\"".format(self.indent * (level + 2), k, v))
+                        self.print("{} />".format(self.indent * (level + 1)))
+                    else:
+                        # Single-line formatting for simple mappings
+                        self.printElement(mapping_elem, level + 1)
+                
+                # Close participant tag
+                self.print("{}</participant>".format(self.indent * level))
+                
+                # Add newline after participant if not the last element
+                if i < last:
+                    self.print()
+                
+                continue
+            
+            # Special handling for coupling-scheme elements
+            elif 'coupling-scheme' in str(group.tag):
+                # Sort children of coupling-scheme
+                sorted_scheme_children = sorted(
+                    group.getchildren(),
+                    key=lambda child: 0 if str(child.tag) == 'relative-convergence-measure' else 
+                                      1 if str(child.tag) == 'exchange' else 2
+                )
+                
+                # Separate different types of elements
+                other_elements = []
+                exchange_elements = []
+                convergence_elements = []
+                acceleration_elements = []
+                
+                for child in sorted_scheme_children:
+                    tag = str(child.tag)
+                    if tag == 'exchange':
+                        exchange_elements.append(child)
+                    elif tag == 'relative-convergence-measure':
+                        convergence_elements.append(child)
+                    elif tag.startswith('acceleration:'):
+                        acceleration_elements.append(child)
+                    else:
+                        other_elements.append(child)
+                
+                # Print coupling-scheme opening tag
+                self.print(self.indent * level + "<{}>".format(group.tag))
+                
+                # Print initial elements
+                initial_elements = [
+                    elem for elem in other_elements 
+                    if str(elem.tag) in ['participants', 'max-time', 'time-window-size']
+                ]
+                for child in initial_elements:
+                    self.printElement(child, level + 1)
+                
+                # Print convergence measures first
+                if convergence_elements:
+                    if initial_elements:
+                        self.print()
+                    for conv in convergence_elements:
+                        self.printElement(conv, level + 1)
+                
+                # Print exchanges
+                if exchange_elements:
+                    if initial_elements or convergence_elements:
+                        self.print()
+                    for exchange in exchange_elements:
+                        self.printElement(exchange, level + 1)
+                
+                # Print max-iterations if present
+                max_iterations = [
+                    elem for elem in other_elements 
+                    if str(elem.tag) == 'max-iterations'
+                ]
+                if max_iterations:
+                    if exchange_elements or convergence_elements or initial_elements:
+                        self.print()
+                    for child in max_iterations:
+                        self.printElement(child, level + 1)
+                
+                # Print acceleration elements
+                if acceleration_elements:
+                    if exchange_elements or convergence_elements or max_iterations or initial_elements:
+                        self.print()
+                    for child in acceleration_elements:
+                        self.printElement(child, level + 1)
+                
+                # Close coupling-scheme tag
+                self.print("{}</{}>"
+                    .format(self.indent * level, group.tag))
+                
+                # Add newline after coupling-scheme if not the last element
+                if i < last:
+                    self.print()
+                
+                continue
+            
+            # Print the element normally
+            self.printElement(group, level=level)
+            
+            # Add an extra newline between top-level groups
+            if i < last:
                 self.print()
 
 

--- a/format_precice_config/format_precice_config.py
+++ b/format_precice_config/format_precice_config.py
@@ -212,14 +212,37 @@ class PrettyPrinter():
                 if data_elements and mapping_elements:
                     self.print()
                 
+                # Separate mapping elements with and without basis-function
+                mapping_with_basis = [
+                    elem for elem in mapping_elements 
+                    if any('basis-function:' in str(child.tag) for child in elem.getchildren())
+                ]
+                mapping_without_basis = [
+                    elem for elem in mapping_elements 
+                    if not any('basis-function:' in str(child.tag) for child in elem.getchildren())
+                ]
+                
                 # Print mapping elements with multi-line formatting
                 for mapping_elem in mapping_elements:
-                    # Check if the mapping element has multiple attributes
+                    # Check if the mapping element has a basis-function child
+                    has_basis_function = any('basis-function:' in str(child.tag) for child in mapping_elem.getchildren())
+                    
+                    # Print the mapping element
                     if len(mapping_elem.items()) > 2:
                         self.print("{}<{}".format(self.indent * (level + 1), mapping_elem.tag))
                         for k, v in mapping_elem.items():
                             self.print("{}{}=\"{}\"".format(self.indent * (level + 2), k, v))
-                        self.print("{} />".format(self.indent * (level + 1)))
+                        
+                        # Add basis-function child if it exists in the original
+                        if has_basis_function:
+                            self.print("{}>".format(self.indent * (level + 1)))
+                            for child in mapping_elem.getchildren():
+                                if 'basis-function:' in str(child.tag):
+                                    self.printElement(child, level + 2)
+                            self.print("{}</{}>"
+                                       .format(self.indent * (level + 1), mapping_elem.tag))
+                        else:
+                            self.print("{} />".format(self.indent * (level + 1)))
                     else:
                         # Single-line formatting for simple mappings
                         self.printElement(mapping_elem, level + 1)

--- a/format_precice_config/format_precice_config.py
+++ b/format_precice_config/format_precice_config.py
@@ -9,6 +9,48 @@ import shutil
 
 CONVERGENCE_MEASURE_TAGS = ['relative-convergence-measure', 'absolute-convergence-measure', 'absolute-or-relative-convergence-measure']
 
+TOP_LEVEL_ORDER = {
+    'data:': 1,
+    'mesh': 2,
+    'participant': 3,
+    'm2n:': 4,
+    'coupling-scheme:': 5
+}
+
+PARTICIPANT_ORDER = {
+    'provide-mesh': 1,
+    'receive-mesh': 2,
+    'write-data': 3,
+    'read-data': 4,
+    'mapping:': 5
+}
+
+def custom_sort_key(elem, order):
+    """
+    Custom sorting key for XML elements like top-level-order.
+    
+    Args:
+        elem (etree._Element): XML element to sort
+        order (dict): Dictionary mapping prefix to rank
+    
+    Returns:
+        int: Sorting rank for the element
+    """
+    tag = str(elem.tag)
+    # Find the first matching key
+    for prefix, rank in order.items():
+        if tag.startswith(prefix):
+            return rank
+    # Dynamically assign the next number for unknown elements
+    if not hasattr(custom_sort_key, 'unknown_counter'):
+        custom_sort_key.unknown_counter = len(order) + 1
+    
+    #Add this? Each time an unknown element is encountered, the counter is incremented, giving each unique unknown element a distinct sorting rank.
+    # custom_sort_key.unknown_counter += 1
+
+    return custom_sort_key.unknown_counter
+
+
 def isEmptyTag(element):
     return not element.getchildren()
 
@@ -118,47 +160,18 @@ class PrettyPrinter():
                 self.printElement(child, level=level)
             return
 
-        # Custom sorting for top-level elements
-        def custom_sort_key(elem):
-            tag = str(elem.tag)
-            # Predefined order for top-level elements with prefix matching
-            order = {
-                'data:': 1,  # Matches data:vector, data:scalar, etc.
-                'mesh': 2,
-                'participant': 3,
-                'm2n:': 4,
-                'coupling-scheme:': 5
-            }
-            # Find the first matching key
-            for prefix, rank in order.items():
-                if tag.startswith(prefix):
-                    return rank
-            return 6  # Unknown elements appear last
-
         # Sort children based on the predefined order
-        sorted_children = sorted(element.getchildren(), key=custom_sort_key)
+        sorted_children = sorted(element.getchildren(), key=lambda elem: custom_sort_key(elem, TOP_LEVEL_ORDER))
 
         last = len(sorted_children)
         for i, group in enumerate(sorted_children, start=1):
             # Special handling for participants to reorder child elements
             if 'participant' in str(group.tag):
-                # Define order for participant child elements with more generalized matching
-                participant_order = {
-                    'provide-mesh': 1,
-                    'receive-mesh': 2,
-                    'write-data': 3,
-                    'read-data': 4,
-                    'mapping:': 5  # Matches mapping:nearest-neighbor, mapping:rbf, etc.
-                }
                 
                 # Sort participant's children based on the defined order
                 sorted_participant_children = sorted(
                     group.getchildren(), 
-                    key=lambda child: next(
-                        (rank for prefix, rank in participant_order.items() 
-                         if str(child.tag).startswith(prefix)), 
-                        6  # Unknown elements appear last
-                    )
+                    key=lambda child: custom_sort_key(child, PARTICIPANT_ORDER)
                 )
                 
                 # Separate different types of elements

--- a/format_precice_config/format_precice_config.py
+++ b/format_precice_config/format_precice_config.py
@@ -7,6 +7,7 @@ import sys
 import io
 import shutil
 
+CONVERGENCE_MEASURE_TAGS = ['relative-convergence-measure', 'absolute-convergence-measure', 'absolute-or-relative-convergence-measure']
 
 def isEmptyTag(element):
     return not element.getchildren()
@@ -224,7 +225,7 @@ class PrettyPrinter():
                 # Sort children of coupling-scheme
                 sorted_scheme_children = sorted(
                     group.getchildren(),
-                    key=lambda child: 0 if str(child.tag) == 'relative-convergence-measure' else 
+                    key=lambda child: 0 if str(child.tag) in CONVERGENCE_MEASURE_TAGS else 
                                       1 if str(child.tag) == 'exchange' else 2
                 )
                 
@@ -238,7 +239,7 @@ class PrettyPrinter():
                     tag = str(child.tag)
                     if tag == 'exchange':
                         exchange_elements.append(child)
-                    elif tag == 'relative-convergence-measure':
+                    elif tag in CONVERGENCE_MEASURE_TAGS:
                         convergence_elements.append(child)
                     elif tag.startswith('acceleration:'):
                         acceleration_elements.append(child)


### PR DESCRIPTION
The goal is to organize and enhance the structure of the elements for improved readability.

## Top-Level Elements
Top-level elements are now sorted in the order:
1. **data**
2. **meshes**
3. **participants**
4. **m2n**
5. **coupling scheme**

Unknown elements will appear last.

## Participant Elements
Participant elements are reordered as follows:
- **First**:
  - `provide-mesh`
  - `receive-mesh`
- **Then**:
  - `write-data`
  - `read-data`
- **Finally**:
  - `mapping:`

A newline is added after read/write mesh elements.

## Coupling Scheme
In the coupling scheme, the following elements are paired together:
~~- `relative-convergence-measure`~~
- all 3 valid `...-convergence-measure` (As long as i didn't forget one)
- `exchange`

## Changes Before and After Calling the Script
Ran the script on the generated (unformatted) Precice Config of https://github.com/precice-forschungsprojekt/PreCICE-Genesis. [before](https://github.com/precice-forschungsprojekt/PreCICE-Genesis/pull/79/commits/5f2ff0b125e7276544f604243938f4141d284b00)
and the result was: [after](https://github.com/precice-forschungsprojekt/PreCICE-Genesis/blob/81f570287a7d9f8ae4be23357b05c2e1d8a574ee/test_input.xml)


---

~~**Note**: This editing is not 100% finished yet and requires further testing. For now, it stays as a draft. However, if any changes are requested, they will be considered for implementation.~~

## Questions

- Are the `initial elements` inside `coupling-scheme` fine as they are, or do you want them changed up a bit ? It is also possible to print all `other elements` in 1 go without adding the empty line after those 3: 'participants', 'max-time', 'time-window-size' [link to line](https://github.com/precice-forschungsprojekt/precice-pre-commit-hooks/blob/9098ce261317c1c17cd4b8d6c4a6d6edb8843ac4/format_precice_config/format_precice_config.py#L253)

- Does it matter for this hook to check for some kind of correctness. What I mean by that is that if for example no exchanges exist. The current logic has an `if exchange_elements` so it only prints the new line when they exist, so there are no multiple empty lines spammed. 
